### PR TITLE
Update architectures patterns

### DIFF
--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|s390|armv6l|armv7l|aarch64)",
+            "match": "(?:s390x|s390|armv6l|armv7l|aarch64|alpha)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -239,7 +239,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:ppc64p7|ppc64leppc64|ppc)",
+            "match": "(?:ppc64p7|ppc64le|ppc64|ppc)",
             "name": "constant.language.spec"
         }
     ]

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|s390|armv6l|armv7l|aarch64|alpha|sparc64)",
+            "match": "(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64)",
+            "match": "(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|s390|armv6l|armv7l|aarch64|alpha)",
+            "match": "(?:s390x|s390|armv6l|armv7l|aarch64|alpha|sparc64)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|armv6l|armv7l|aarch64)",
+            "match": "(?:s390x|s390|armv6l|armv7l|aarch64)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -235,7 +235,7 @@
             "name": "constant.language.spec"
         },
         {
-            "match": "(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9)",
+            "match": "(?:s390x|s390|armv6l|armv7hl|armv7l|aarch64|alpha|sparc64|sparcv9|sparc)",
             "name": "constant.language.spec"
         },
         {

--- a/syntaxes/spec.json
+++ b/syntaxes/spec.json
@@ -231,7 +231,7 @@
   "architectures": {
     "patterns": [
         {
-            "match": "(?:noarch|i386|i586|i686|x86_64|local)",
+            "match": "(?:noarch|i386|i586|i686|x86_64|ia64|local)",
             "name": "constant.language.spec"
         },
         {


### PR DESCRIPTION
This pull request fixes ppc64le and ppc64 patterns, and add new patterns for some missing architectures (s390, ia64, alpha, sparc64, armv7hl, sparcv9, sparc).

Inspired in waveclaw/language-rpm-spec/pull/15.